### PR TITLE
patch: fix behaviour change when detecting android tablets

### DIFF
--- a/ua.go
+++ b/ua.go
@@ -171,7 +171,7 @@ func Parse(userAgent string) UserAgent {
 		ua.Name = Firefox
 		ua.Version = tokens.get(Firefox)
 		ua.Mobile = tokens.exists("Mobile")
-		ua.Tablet = tokens.exists("Tablet")
+		ua.Tablet = strings.Contains(strings.ToLower(ua.String), "tablet")
 
 	case tokens.get("Vivaldi") != "":
 		ua.Name = Vivaldi

--- a/ua_test.go
+++ b/ua_test.go
@@ -36,7 +36,11 @@ var testTable = [][]string{
 	{"Mozilla/5.0 (iPad; CPU OS 10_3_2 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/58.0.3029.113 Mobile/14F89 Safari/602.1", ua.Chrome, "58.0.3029.113", "tablet", "iOS", "iPad"},
 	{"Mozilla/5.0 (iPad; CPU OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) FxiOS/8.1.1b4948 Mobile/14F89 Safari/603.2.4", ua.Firefox, "8.1.1b4948", "tablet", "iOS", "iPad"},
 
-	// Andorid
+	// Android Tablet
+	{"Mozilla/5.0 (Android 4.4; Tablet; rv:41.0) Gecko/41.0 Firefox/41.0", ua.Firefox, "41.0", "tablet", "Android", "Tablet"},
+	{"Mozilla/5.0 (Linux; Android 9; Chrome tablet) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Mobile Safari/537.36", ua.Chrome, "110.0.0.0", "tablet", "Android", "Chrome tablet"},
+
+	// Android
 	{"Mozilla/5.0 (Linux; Android 4.3; GT-I9300 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36", ua.Chrome, "59.0.3071.125", "mobile", "Android", "GT-I9300"},
 	{"Mozilla/5.0 (Android 4.3; Mobile; rv:54.0) Gecko/54.0 Firefox/54.0", ua.Firefox, "54.0", "mobile", "Android"},
 	{"Mozilla/5.0 (Linux; Android 4.3; GT-I9300 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36 OPR/42.9.2246.119956", ua.Opera, "42.9.2246.119956", "mobile", ua.Android},


### PR DESCRIPTION
Noticed a regression when I bumped the usage of this library to the latest version.

Looking at the blame I don't see why this really changed behaviour but the proposed PR reverts it so that the following UA is detected as a table:

```
	{"Mozilla/5.0 (Android 4.4; Tablet; rv:41.0) Gecko/41.0 Firefox/41.0", ua.Firefox, "41.0", "tablet", "Android", "Tablet"},
```

I also added the following as an additional sanity check as I noticed there's not any cases for specifically android tablets.

```
	{"Mozilla/5.0 (Linux; Android 9; Chrome tablet) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Mobile Safari/537.36", ua.Chrome, "110.0.0.0", "tablet", "Android", "Chrome tablet"},
```

