### PR TITLE
feat(json): added struct tags to ensure JSON is standardised

### DIFF
--- a/ua.go
+++ b/ua.go
@@ -8,19 +8,19 @@ import (
 
 // UserAgent struct containing all data extracted from parsed user-agent string
 type UserAgent struct {
-	VersionNo   VersionNo
-	OSVersionNo VersionNo
-	URL         string
-	String      string
-	Name        string
-	Version     string
-	OS          string
-	OSVersion   string
-	Device      string
-	Mobile      bool
-	Tablet      bool
-	Desktop     bool
-	Bot         bool
+	VersionNo   VersionNo `json:"version_no,omitempty"`
+	OSVersionNo VersionNo `json:"os_version_no,omitempty"`
+	URL         string    `json:"url,omitempty"`
+	String      string    `json:"string,omitempty"`
+	Name        string    `json:"name,omitempty"`
+	Version     string    `json:"version,omitempty"`
+	OS          string    `json:"os,omitempty"`
+	OSVersion   string    `json:"os_version,omitempty"`
+	Device      string    `json:"device,omitempty"`
+	Mobile      bool      `json:"mobile,omitempty"`
+	Tablet      bool      `json:"tablet,omitempty"`
+	Desktop     bool      `json:"desktop,omitempty"`
+	Bot         bool      `json:"bot,omitempty"`
 }
 
 // Constants for browsers and operating systems for easier comparison

--- a/version.go
+++ b/version.go
@@ -7,9 +7,9 @@ import (
 )
 
 type VersionNo struct {
-	Major int
-	Minor int
-	Patch int
+	Major int `json:"major,omitempty"`
+	Minor int `json:"minor,omitempty"`
+	Patch int `json:"patch,omitempty"`
 }
 
 func parseVersion(ver string, verno *VersionNo) {


### PR DESCRIPTION
I would love to be able to serialize the results of this library and store it so I can query it, standardized tag naming makes that easier.

This only really effects the models returned by the `Parse` method and saves people messing with the data or building their own models.