### PR TITLE
"macOS" > "Mac OS X"

### DIFF
--- a/ua.go
+++ b/ua.go
@@ -28,7 +28,7 @@ const (
 	Windows      = "Windows"
 	WindowsPhone = "Windows Phone"
 	Android      = "Android"
-	MacOS        = "macOS"
+	MacOS        = "Mac OS X"
 	IOS          = "iOS"
 	Linux        = "Linux"
 	FreeBSD      = "FreeBSD"


### PR DESCRIPTION
Newer MacBooks use "Mac OS X"